### PR TITLE
fix(flows): flow-log endpoint fixes + /health/* primitives

### DIFF
--- a/nexla_sdk/resources/flows.py
+++ b/nexla_sdk/resources/flows.py
@@ -406,6 +406,108 @@ class FlowsResource(BaseResource):
 
         return self._make_request("POST", path, params=params, json=body)
 
+    def get_org_health_summary(
+        self,
+        org_id: int = None,
+        owner_id: int = None,
+        from_date: str = None,
+        to_date: str = None,
+    ) -> Dict[str, Any]:
+        """
+        Get the overall health snapshot for an org's flows.
+
+        Calls ``GET /health/org/all``. Returns aggregate counts of flows
+        bucketed by their current health status (GREEN/YELLOW/RED) across
+        the optional date window.
+
+        Args:
+            org_id: Organization ID (defaults server-side to current org)
+            owner_id: Restrict to flows owned by this user
+            from_date: Start date (YYYY-MM-DD, treated as UTC)
+            to_date: End date (YYYY-MM-DD, treated as UTC)
+
+        Returns:
+            Aggregate health metrics for the org
+        """
+        params: Dict[str, Any] = {}
+        if org_id is not None:
+            params["org_id"] = org_id
+        if owner_id is not None:
+            params["owner_id"] = owner_id
+        if from_date is not None:
+            params["from"] = from_date
+        if to_date is not None:
+            params["to"] = to_date
+        return self._make_request("GET", "/health/org/all", params=params)
+
+    def get_org_health_flows(
+        self,
+        org_id: int = None,
+        owner_id: int = None,
+        from_date: str = None,
+        to_date: str = None,
+        health_status: str = None,
+        page: int = None,
+        size: int = None,
+        sort_by: str = None,
+        sort_order: str = None,
+    ) -> Dict[str, Any]:
+        """
+        List per-flow health status across an org. Use this to answer
+        questions like "which flows had errors today" or "show me unhealthy
+        flows in the last week".
+
+        Calls ``GET /health/org/flows``. Each entry includes the flow's
+        origin_node_id, current healthStatus, latestErrorCount,
+        latestRecordCount, latestRunId, errorSummary, and updatedAtEpoch.
+
+        Args:
+            org_id: Organization ID (defaults server-side to current org)
+            owner_id: Restrict to flows owned by this user
+            from_date: Start date (YYYY-MM-DD, treated as UTC)
+            to_date: End date (YYYY-MM-DD, treated as UTC)
+            health_status: Filter to one of GREEN (OK), YELLOW (WARNING),
+                or RED (ERROR). Case-insensitive.
+            page: 1-based page number
+            size: Page size
+            sort_by: Field to sort by (e.g. ``run_id``, ``updated_at``)
+            sort_order: ``asc`` or ``desc``
+
+        Returns:
+            Paginated list of flow health entries
+        """
+        params: Dict[str, Any] = {}
+        if org_id is not None:
+            params["org_id"] = org_id
+        if owner_id is not None:
+            params["owner_id"] = owner_id
+        if from_date is not None:
+            params["from"] = from_date
+        if to_date is not None:
+            params["to"] = to_date
+        if health_status is not None:
+            params["health_status"] = health_status
+        if page is not None:
+            params["page"] = page
+        if size is not None:
+            params["size"] = size
+        if sort_by is not None:
+            params["sort_by"] = sort_by
+        if sort_order is not None:
+            params["sort_order"] = sort_order
+        return self._make_request("GET", "/health/org/flows", params=params)
+
+    def get_flow_health(self, flow_id: int) -> Dict[str, Any]:
+        """
+        Get detailed health information for a single flow.
+
+        Calls ``GET /health/flow/:flow_id``. Returns the flow's current
+        health status plus a breakdown of latest errors / records / run
+        information; the inverse of :meth:`get_org_health_flows` for one
+        specific flow.
+        """
+        return self._make_request("GET", f"/health/flow/{flow_id}")
+
     def get_active_flows_metrics(
         self, from_date: str = None, to_date: str = None, org_id: int = None
     ) -> Dict[str, Any]:

--- a/nexla_sdk/resources/flows.py
+++ b/nexla_sdk/resources/flows.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Union
 
 from nexla_sdk.models.flows.requests import FlowCopyOptions
@@ -8,6 +9,28 @@ from nexla_sdk.models.flows.responses import (
     FlowResponse,
 )
 from nexla_sdk.resources.base_resource import BaseResource
+
+
+def _iso_date_to_unix_seconds(value: Any) -> Any:
+    """
+    Convert a YYYY-MM-DD string to a UTC unix-seconds integer for admin-api
+    log endpoints, which run inputs through ``DateInterval.unix_to_db_datetime_str``.
+
+    Numeric inputs (int/float, or all-digit strings) pass through unchanged so
+    callers that already use unix timestamps keep working. Unrecognised values
+    pass through unchanged for the server to handle. ``None`` returns ``None``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    try:
+        dt = datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        return int(dt.timestamp())
+    except (TypeError, ValueError):
+        return value
 
 
 class FlowsResource(BaseResource):
@@ -296,12 +319,14 @@ class FlowsResource(BaseResource):
         Returns:
             Flow execution logs
         """
-        path = f"{self._path}/{flow_id}/flow/logs"
+        path = f"{self._path}/{flow_id}/logs"
         params = {}
-        if from_date is not None:
-            params["from"] = from_date
-        if to_date is not None:
-            params["to"] = to_date
+        from_ts = _iso_date_to_unix_seconds(from_date)
+        if from_ts is not None:
+            params["from"] = from_ts
+        to_ts = _iso_date_to_unix_seconds(to_date)
+        if to_ts is not None:
+            params["to"] = to_ts
         if severity is not None:
             params["severity"] = severity
         if run_id is not None:
@@ -315,39 +340,71 @@ class FlowsResource(BaseResource):
     def search_flow_logs(
         self,
         flow_id: int,
-        run_ids: str = None,
-        severity: str = None,
+        run_ids: Union[str, List[int]] = None,
+        severity: Union[str, List[str]] = None,
+        log_type: Union[str, List[str]] = None,
         search_string: str = None,
         from_date: str = None,
         to_date: str = None,
+        size: int = None,
+        sort: str = None,
+        facets: bool = None,
     ) -> Dict[str, Any]:
         """
         Advanced search for flow execution logs.
 
+        Calls ``POST /flows/:id/logs_v2``. ``severity``/``run_ids``/``log_type``/
+        ``search_string`` are sent in the JSON body (the admin-api endpoint
+        requires this); ``from``/``to``/``sort``/``size``/``facets`` are sent
+        as query parameters.
+
         Args:
             flow_id: Flow ID
-            run_ids: Comma-separated list of run IDs to filter
-            severity: Filter by log severity
+            run_ids: Run IDs to filter — comma-separated string or list of ints
+            severity: Log severity (e.g. "ERROR") or list of severities
+            log_type: Log type or list of log types
             search_string: Free-text search string
             from_date: Start date filter (YYYY-MM-DD)
             to_date: End date filter (YYYY-MM-DD)
+            size: Page size
+            sort: Sort directive
+            facets: Whether to include facet aggregations in the response
 
         Returns:
             Matching flow logs
         """
         path = f"{self._path}/{flow_id}/logs_v2"
-        params = {}
+
+        body: Dict[str, Any] = {}
         if run_ids is not None:
-            params["run_ids"] = run_ids
+            if isinstance(run_ids, str):
+                parsed = [int(s) for s in run_ids.split(",") if s.strip()]
+            else:
+                parsed = [int(r) for r in run_ids]
+            if parsed:
+                body["run_ids"] = parsed
         if severity is not None:
-            params["severity"] = severity
+            body["severity"] = [severity] if isinstance(severity, str) else list(severity)
+        if log_type is not None:
+            body["log_type"] = [log_type] if isinstance(log_type, str) else list(log_type)
         if search_string is not None:
-            params["search_string"] = search_string
-        if from_date is not None:
-            params["from"] = from_date
-        if to_date is not None:
-            params["to"] = to_date
-        return self._make_request("GET", path, params=params)
+            body["search_string"] = search_string
+
+        params: Dict[str, Any] = {}
+        from_ts = _iso_date_to_unix_seconds(from_date)
+        if from_ts is not None:
+            params["from"] = from_ts
+        to_ts = _iso_date_to_unix_seconds(to_date)
+        if to_ts is not None:
+            params["to"] = to_ts
+        if size is not None:
+            params["size"] = size
+        if sort is not None:
+            params["sort"] = sort
+        if facets is not None:
+            params["facets"] = facets
+
+        return self._make_request("POST", path, params=params, json=body)
 
     def get_active_flows_metrics(
         self, from_date: str = None, to_date: str = None, org_id: int = None

--- a/tests/unit/test_flows.py
+++ b/tests/unit/test_flows.py
@@ -583,6 +583,87 @@ class TestFlowsUnit:
         assert last_request["params"]["page"] == 1
         assert last_request["params"]["per_page"] == 50
 
+    def test_get_flow_logs_uses_flat_logs_path(self, mock_client, mock_http_client):
+        """get_flow_logs hits /flows/:id/logs (not /flow/logs) and unix-encodes dates."""
+        flow_id = 591210
+        mock_http_client.add_response(
+            f"/flows/{flow_id}/logs", {"status": 200, "logs": []}
+        )
+
+        mock_client.flows.get_flow_logs(
+            flow_id=flow_id,
+            from_date="2026-05-09",
+            to_date="2026-05-10",
+            severity="ERROR",
+            run_id=42,
+        )
+
+        req = mock_http_client.get_last_request()
+        assert req["method"] == "GET"
+        assert req["url"].endswith(f"/flows/{flow_id}/logs")
+        assert "/flow/logs" not in req["url"]
+        assert req["params"]["severity"] == "ERROR"
+        assert req["params"]["run_id"] == 42
+        # 2026-05-09 00:00:00 UTC → 1778284800; 2026-05-10 → 1778371200
+        assert req["params"]["from"] == 1778284800
+        assert req["params"]["to"] == 1778371200
+
+    def test_get_flow_logs_passes_through_unix_timestamps(
+        self, mock_client, mock_http_client
+    ):
+        """get_flow_logs leaves unix-timestamp inputs unchanged."""
+        mock_http_client.add_response("/flows/1/logs", {"status": 200, "logs": []})
+        mock_client.flows.get_flow_logs(flow_id=1, from_date=1704067200, to_date="1704153600")
+        req = mock_http_client.get_last_request()
+        assert req["params"]["from"] == 1704067200
+        assert req["params"]["to"] == 1704153600
+
+    def test_search_flow_logs_uses_post_with_body(self, mock_client, mock_http_client):
+        """search_flow_logs POSTs body params and unix-encodes from/to."""
+        flow_id = 591210
+        mock_http_client.add_response(
+            f"/flows/{flow_id}/logs_v2", {"status": 200, "logs": []}
+        )
+
+        mock_client.flows.search_flow_logs(
+            flow_id=flow_id,
+            run_ids=[1778284990535, 1778284990536],
+            severity="ERROR",
+            log_type=["execution"],
+            search_string="schema mismatch",
+            from_date="2026-05-09",
+            to_date="2026-05-09",
+            size=100,
+            facets=True,
+        )
+
+        req = mock_http_client.get_last_request()
+        assert req["method"] == "POST"
+        assert req["url"].endswith(f"/flows/{flow_id}/logs_v2")
+        # body
+        assert req["json"]["run_ids"] == [1778284990535, 1778284990536]
+        assert req["json"]["severity"] == ["ERROR"]
+        assert req["json"]["log_type"] == ["execution"]
+        assert req["json"]["search_string"] == "schema mismatch"
+        # query
+        assert req["params"]["from"] == 1778284800
+        assert req["params"]["to"] == 1778284800
+        assert req["params"]["size"] == 100
+        assert req["params"]["facets"] is True
+        # body fields must NOT leak into the query string
+        assert "severity" not in req["params"]
+        assert "run_ids" not in req["params"]
+        assert "search_string" not in req["params"]
+
+    def test_search_flow_logs_accepts_run_ids_string(
+        self, mock_client, mock_http_client
+    ):
+        """Comma-separated run_ids string is split into a list of ints."""
+        mock_http_client.add_response("/flows/1/logs_v2", {"status": 200, "logs": []})
+        mock_client.flows.search_flow_logs(flow_id=1, run_ids="10,20,30")
+        req = mock_http_client.get_last_request()
+        assert req["json"]["run_ids"] == [10, 20, 30]
+
     def test_get_metrics_success(self, mock_client, mock_http_client):
         """Test get_metrics returns FlowMetricsApiResponse model."""
         # Arrange


### PR DESCRIPTION
## Summary
Stacked on top of `feat/monitoring-sdk-methods`. Two semantic commits:

1. **fix(flows): correct flow-log HTTP method, path, and date encoding** — Production-impacting bugs surfaced by the veda-ai monitoring MCP:
   - `search_flow_logs` was sending `GET /flows/:id/logs_v2` (admin-api defines `POST`) with body fields stuffed into the query string. Now `POST`, with `severity` / `run_ids` / `log_type` / `search_string` in the JSON body and `from` / `to` / `size` / `sort` / `facets` in the query, matching `routes.rb:790` + `flows_controller.rb#flow_logs_v2`.
   - `get_flow_logs` hit `/flows/:id/flow/logs`, which 404s — admin-api defines `/flows/:id/logs` (the `flow/logs` form only exists scoped under `data_sources` / `data_sets` / `data_sinks`).
   - Both endpoints run `from`/`to` through `DateInterval.unix_to_db_datetime_str` server-side, which expects unix seconds. The SDK was forwarding raw `YYYY-MM-DD` strings; `"2026-05-09".to_i == 2026` was interpreted as ~1970-01-01 and matched no logs. New `_iso_date_to_unix_seconds` helper converts ISO dates and passes numeric/unix inputs through unchanged.
   - Bonus: exposes `log_type` / `size` / `sort` / `facets` (admin-api accepts them) and `run_ids` now accepts either a comma-string or a list of ints.

2. **feat(flows): add /health/org/* and /health/flow/:id primitives** — Three new SDK methods wrapping admin-api's health endpoints (downstream of `backend-monitoring`):
   - `get_org_health_summary` → `GET /health/org/all`
   - `get_org_health_flows` → `GET /health/org/flows` (supports `health_status` enum: GREEN / YELLOW / RED)
   - `get_flow_health` → `GET /health/flow/:flow_id`

   Per-flow response shape documented from `HealthMonitoringFlow.java`: `originNodeId`, `healthStatus`, `latestErrorCount`, `latestRecordCount`, `latestRunId`, `errorSummary`, `updatedAtEpoch`, `orgId`, `ownerId`.

## Test plan
- [x] Unit tests added: `tests/unit/test_flows.py` — `test_get_flow_logs_uses_flat_logs_path`, `test_get_flow_logs_passes_through_unix_timestamps`, `test_search_flow_logs_uses_post_with_body`, `test_search_flow_logs_accepts_run_ids_string`. All assert method, URL, body vs query split, and date encoding.
- [x] Manual smoke-test via in-process mock HTTP client (the SDK's `MockHTTPClient`) — all flow-log and health methods produce the correct method/path/params.
- [ ] Run full test suite (`pytest tests/unit/test_flows.py`) after merging `feat/monitoring-sdk-methods` (the parent branch).
- [ ] After release, bump the pin in `veda-ai/pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)