### PR TITLE
fix: active_flows_metrics path + LogEntry impersonator_id type

### DIFF
--- a/nexla_sdk/models/common.py
+++ b/nexla_sdk/models/common.py
@@ -60,7 +60,8 @@ class LogEntry(BaseModel):
     owner_email: str
     created_at: datetime
     association_resource: Optional[Dict[str, Any]] = None
-    impersonator_id: Optional[str] = None
+    # admin-api returns the impersonating user's numeric id, not a string.
+    impersonator_id: Optional[int] = None
 
 
 class FlowNode(BaseModel):

--- a/nexla_sdk/resources/flows.py
+++ b/nexla_sdk/resources/flows.py
@@ -645,7 +645,10 @@ class FlowsResource(BaseResource):
         Returns:
             Active flows metrics
         """
-        path = f"{self._path}/active_flows_metrics"
+        # Admin-api defines this route at /data_flows/metrics/active_flows_metrics
+        # (config/routes.rb), not under /flows/. Calling /flows/active_flows_metrics
+        # 404s.
+        path = "/data_flows/metrics/active_flows_metrics"
         params = {}
         if from_date is not None:
             params["from"] = from_date

--- a/tests/unit/test_doc_containers.py
+++ b/tests/unit/test_doc_containers.py
@@ -33,3 +33,30 @@ class TestDocContainersResource:
         out = client.doc_containers.get_audit_log(10)
         assert isinstance(out[0], LogEntry)
         mock_http_client.assert_request_made("GET", "/doc_containers/10/audit_log")
+
+    def test_audit_log_parses_integer_impersonator_id(
+        self, client, mock_http_client
+    ):
+        """admin-api returns ``impersonator_id`` as the impersonating user's
+        numeric id when impersonation is active. Earlier the SDK typed this
+        as ``Optional[str]`` and validation failed on real responses."""
+        log = {
+            "id": 2,
+            "item_type": "DOC_CONTAINER",
+            "item_id": 10,
+            "event": "updated",
+            "change_summary": ["updated"],
+            "object_changes": {"name": ["old", "new"]},
+            "request_ip": "127.0.0.1",
+            "request_user_agent": "pytest",
+            "request_url": "http://x",
+            "user": {"id": 1},
+            "org_id": 1,
+            "owner_id": 1,
+            "owner_email": "a@b.com",
+            "created_at": "2023-01-01T00:00:00Z",
+            "impersonator_id": 5,  # numeric, not string
+        }
+        mock_http_client.add_response("/doc_containers/10/audit_log", [log])
+        out = client.doc_containers.get_audit_log(10)
+        assert out[0].impersonator_id == 5

--- a/tests/unit/test_flows.py
+++ b/tests/unit/test_flows.py
@@ -823,6 +823,27 @@ class TestFlowsUnit:
         req = mock_http_client.get_last_request()
         assert req["json"]["run_ids"] == [10, 20, 30]
 
+    def test_get_active_flows_metrics_uses_data_flows_metrics_path(
+        self, mock_client, mock_http_client
+    ):
+        """admin-api defines the route as /data_flows/metrics/active_flows_metrics.
+        Calling /flows/active_flows_metrics 404s in production."""
+        mock_http_client.add_response(
+            "/data_flows/metrics/active_flows_metrics", {"metrics": []}
+        )
+
+        mock_client.flows.get_active_flows_metrics(
+            from_date="2026-05-01", to_date="2026-05-13", org_id=484
+        )
+
+        req = mock_http_client.get_last_request()
+        assert req["method"] == "GET"
+        assert req["url"].endswith("/data_flows/metrics/active_flows_metrics")
+        assert "/flows/active_flows_metrics" not in req["url"]
+        assert req["params"]["from"] == "2026-05-01"
+        assert req["params"]["to"] == "2026-05-13"
+        assert req["params"]["org_id"] == 484
+
     def test_get_metrics_success(self, mock_client, mock_http_client):
         """Test get_metrics returns FlowMetricsApiResponse model."""
         # Arrange


### PR DESCRIPTION
## Summary
Two production-impacting bugs surfaced by live testing of the monitoring MCP against ``veda-ai.nexla.io``.

### 1. fix(flows): correct get_active_flows_metrics path
``flows.get_active_flows_metrics`` was hitting ``/flows/active_flows_metrics``, which 404s. The admin-api route is ``/data_flows/metrics/active_flows_metrics`` (``config/routes.rb:929``). Every call was failing on production until I tested directly.

### 2. fix(models): LogEntry.impersonator_id should be int, not str
``LogEntry.impersonator_id`` was typed as ``Optional[str]``. Admin-api returns the impersonating user's **numeric** id whenever the calling token is impersonating. Pydantic raises ``ValidationError: Input should be a valid string`` on every real audit_log response from an impersonated session, breaking ``get_nexla_org_audit_log`` and any sibling audit-log call where impersonation is active.

Concrete example: tested with a token whose ``auid`` claim is 5 against ``/orgs/{id}/audit_log``; admin-api returned ``impersonator_id: 5`` (int), Pydantic blew up.

## Test plan
- [x] New unit test in ``test_flows.py``: asserts ``get_active_flows_metrics`` hits ``/data_flows/metrics/active_flows_metrics`` and not ``/flows/active_flows_metrics``.
- [x] New unit test in ``test_doc_containers.py``: ``LogEntry`` round-trips with an integer ``impersonator_id`` (5).
- [x] In-process smoke test: both fixes produce the right HTTP call and parse the right response.
- [ ] After release, bump the pin in ``veda-ai/pyproject.toml`` (the matching veda-ai PR will land alongside).

## Related
- veda-ai PR https://github.com/nexla/veda-ai/pull/new/fix/monitoring-mcp-followups consumes these fixes plus a default-org resolution fix on the MCP server side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)